### PR TITLE
atom: Add prepare() function:

### DIFF
--- a/atom-editor-git/PKGBUILD
+++ b/atom-editor-git/PKGBUILD
@@ -5,7 +5,7 @@
 # https://github.com/jreese/arch
 
 pkgname=atom-editor-git
-pkgver=20141016
+pkgver=0.141.0.r22.gba64268
 pkgrel=1
 pkgdesc="Chrome-based text editor from Github"
 arch=('x86_64' 'i686')
@@ -20,11 +20,22 @@ _gitroot="git://github.com/atom/atom"
 _gitname="atom"
 
 source=("$_gitroot" 'atom-python.patch')
-sha256sums=('SKIP' '18a19b895afbb5c72fe73b1efb37a662e8e8fa0f4731c9fa634f58c341c5ec3b')
+sha256sums=('SKIP' '5cc1a3e30334e92aaea88389d653c20b717ef7c205474705e9f5a356143d18a4')
 
 pkgver() {
   cd "$srcdir/$_gitname"
-  git log -1 --format="%cd" --date=short | sed 's|-||g'
+  git describe --long --tags | sed -r 's/([^-]*-g)/r\1/;s/-/./g;s/v//'
+}
+
+prepare() {
+  cd "$_gitname"
+
+  patch -Np0 -i "$srcdir/atom-python.patch"
+
+  sed -e "s/<%= description %>/$pkgdesc/" \
+    -e "s|<%= installDir %>/share/atom/atom|/usr/bin/atom|"\
+    -e "s|<%= iconName %>|atom|"\
+    resources/linux/atom.desktop.in > resources/linux/Atom.desktop
 }
 
 package() {
@@ -36,14 +47,7 @@ package() {
   script/build --install-dir=$pkgdir/usr
   script/grunt install
 
-  patch "$pkgdir/usr/bin/atom" < "$srcdir/atom-python.patch"
-
-  sed -e "s/<%= description %>/$pkgdesc/" \
-    -e "s|<%= installDir %>/share/atom/atom|/usr/bin/atom|"\
-    -e "s|<%= iconName %>|atom|"\
-    resources/linux/atom.desktop.in > resources/linux/Atom.desktop
-  install -Dm644 resources/linux/Atom.desktop "$pkgdir/usr/share/applications/Atom.desktop"
-
+  install -Dm644 resources/linux/Atom.desktop "$pkgdir/usr/share/applications/atom.desktop"
   install -Dm644 resources/atom.png "$pkgdir/usr/share/pixmaps/atom.png"
   install -Dm644 LICENSE.md "$pkgdir/usr/share/licenses/$pkgname/LICENSE.md"
 }

--- a/atom-editor-git/atom-python.patch
+++ b/atom-editor-git/atom-python.patch
@@ -1,10 +1,9 @@
---- atom.sh.orig	2014-07-24 18:49:00.022810114 -0700
+--- atom.sh	2014-07-24 18:49:00.022810114 -0700
 +++ atom.sh	2014-07-24 18:49:15.993257782 -0700
 @@ -70,6 +70,7 @@
    USR_DIRECTORY=$(readlink -f $(dirname $SCRIPT)/..)
    ATOM_PATH="$USR_DIRECTORY/share/atom/atom"
    DOT_ATOM_DIR="$HOME/.atom"
 +  export PYTHON=python2
- 
-   if [ ! -d "$DOT_ATOM_DIR" ]; then
-     mkdir -p "$DOT_ATOM_DIR"
+
+   mkdir -p "$DOT_ATOM_DIR"

--- a/atom-editor/PKGBUILD
+++ b/atom-editor/PKGBUILD
@@ -11,14 +11,27 @@ pkgdesc="Chrome-based text editor from Github"
 arch=('x86_64' 'i686')
 url="https://github.com/atom/atom"
 license=('MIT')
-conflicts=('atom-editor-git')
 depends=('alsa-lib' 'gconf' 'gtk2' 'libatomic_ops' 'libgcrypt' 'libgnome-keyring' 'libnotify' 'libxtst' 'nodejs' 'nss' 'python2')
-source=("https://github.com/atom/atom/archive/v${pkgver}.tar.gz" 'atom-python.patch')
-sha256sums=('81d93e1158788fef4449b932e9837f2a1951c88177644524f209ccaf5efc23e8' '18a19b895afbb5c72fe73b1efb37a662e8e8fa0f4731c9fa634f58c341c5ec3b')
 makedepends=('git')
+source=("https://github.com/atom/atom/archive/v${pkgver}.tar.gz"
+	'atom-python.patch')
+sha256sums=('81d93e1158788fef4449b932e9837f2a1951c88177644524f209ccaf5efc23e8'
+            '222a63a9773c4c406d6fbe7fc06f05535696168a32d39e9be65118a67b935ce6')
 
 _gitref='02d20e3155821b093e82fa4998cd61a4d28f3d60'
 _gitbranch='master'
+
+
+prepare() {
+  cd "atom-$pkgver"
+
+  patch -Np0 -i "$srcdir/atom-python.patch"
+
+  sed -e "s/<%= description %>/$pkgdesc/" \
+    -e "s|<%= installDir %>/share/atom/atom|/usr/bin/atom|"\
+    -e "s|<%= iconName %>|atom|"\
+    resources/linux/atom.desktop.in > resources/linux/Atom.desktop
+}
 
 package() {
   cd "$srcdir/atom-$pkgver"
@@ -31,14 +44,7 @@ package() {
   script/build --install-dir=$pkgdir/usr
   script/grunt install
 
-  patch "$pkgdir/usr/bin/atom" < "$srcdir/atom-python.patch"
-
-  sed -e "s/<%= description %>/$pkgdesc/" \
-    -e "s|<%= installDir %>/share/atom/atom|/usr/bin/atom|"\
-    -e "s|<%= iconName %>|atom|"\
-    resources/linux/atom.desktop.in > resources/linux/Atom.desktop
-  install -Dm644 resources/linux/Atom.desktop "$pkgdir/usr/share/applications/Atom.desktop"
-
+  install -Dm644 resources/linux/Atom.desktop "$pkgdir/usr/share/applications/atom.desktop"
   install -Dm644 resources/atom.png "$pkgdir/usr/share/pixmaps/atom.png"
   install -Dm644 LICENSE.md "$pkgdir/usr/share/licenses/$pkgname/LICENSE.md"
 }

--- a/atom-editor/atom-python.patch
+++ b/atom-editor/atom-python.patch
@@ -1,4 +1,4 @@
---- atom.sh.orig	2014-07-24 18:49:00.022810114 -0700
+--- atom.sh	2014-07-24 18:49:00.022810114 -0700
 +++ atom.sh	2014-07-24 18:49:15.993257782 -0700
 @@ -70,6 +70,7 @@
    USR_DIRECTORY=$(readlink -f $(dirname $SCRIPT)/..)
@@ -6,5 +6,4 @@
    DOT_ATOM_DIR="$HOME/.atom"
 +  export PYTHON=python2
  
-   if [ ! -d "$DOT_ATOM_DIR" ]; then
-     mkdir -p "$DOT_ATOM_DIR"
+   mkdir -p "$DOT_ATOM_DIR"


### PR DESCRIPTION
Changing the source (like patching and seding) should be done in the prepare() function (if possible).
In this case it's possible and the changes don't get lost.

---

Like the commit message says. The package should still be the same (cannot test it right now, as atom fails to download some sourcefiles. The service is somewhat unstable at the moment (and with both PKGBuilds :P))
